### PR TITLE
Validação de ApiKey de sistema

### DIFF
--- a/nsj_flask_auth/exceptions.py
+++ b/nsj_flask_auth/exceptions.py
@@ -11,3 +11,6 @@ class Forbidden(Exception):
 
 class InternalUnauthorized(Exception):
     pass
+
+class UnknowAuthorizationException(Exception):
+    pass


### PR DESCRIPTION
Adiciona nova forma de validação de apikey:
- Header 'Authorization' no formato `Basic base64(codigo_sistema:token_sistema)`

Quando o header 'Authorization' é informado sem prefixo, a validação segue via access token